### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/packages/core/bootstrap/src/lib/modules/overrider.ts
+++ b/packages/core/bootstrap/src/lib/modules/overrider.ts
@@ -114,11 +114,11 @@ export class Overrider {
     internalOverrides: AdapterOverrides,
     inputOverrides: AdapterOverrides,
   ): AdapterOverrides => {
-    const combinedOverrides = internalOverrides || {}
-    for (const symbol of Object.keys(inputOverrides)) {
-      combinedOverrides[symbol] = inputOverrides[symbol]
+    const combinedOverrides = new Map(Object.entries(internalOverrides || {}))
+    for (const [symbol, value] of Object.entries(inputOverrides)) {
+      combinedOverrides.set(symbol, value)
     }
-    return combinedOverrides
+    return Object.fromEntries(combinedOverrides)
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/pwnlaboratory/external-adapters-js/security/code-scanning/1](https://github.com/pwnlaboratory/external-adapters-js/security/code-scanning/1)

To fix the prototype pollution vulnerability, we should ensure that the keys used in the `combineOverrides` method cannot be used to modify the `Object.prototype`. One effective way to achieve this is by using a `Map` object instead of a plain object for `combinedOverrides`. This will prevent any prototype pollution since `Map` does not have the same prototype properties as plain objects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
